### PR TITLE
Fix NPE with Mob Grinding Utils

### DIFF
--- a/src/main/java/dev/muon/irons_apothic/util/SpellCastUtil.java
+++ b/src/main/java/dev/muon/irons_apothic/util/SpellCastUtil.java
@@ -74,6 +74,12 @@ public class SpellCastUtil {
             IronsApothic.LOGGER.warn("Attempted to trigger affix-cast while player was already casting");
             return;
         }
+        if (magicData.getAdditionalCastData() instanceof TargetEntityCastData targetingData) {
+            // This can happen when getting damaged by some FakePlayer(s)
+            if (targetingData.getTarget((ServerLevel) serverPlayer.level()) == null) {
+                return;
+            }
+        }
         // No precast conditions check here either
         if (serverPlayer.isUsingItem()) {
             serverPlayer.stopUsingItem();


### PR DESCRIPTION
Written on a phone so hopefully this compiles

This fixes an NPE which happens later in the debug log. Another solution would've been to wrap the log string in a `Supplier<String>`, but since the `magicData` is passed down to the spell, it could've created more issues down the line.